### PR TITLE
Docker toolbox rename

### DIFF
--- a/mac
+++ b/mac
@@ -134,7 +134,7 @@ brew 'heroku-toolbelt'
 cask 'google-chrome'
 cask 'slack'
 cask 'intellij-idea'
-cask 'dockertoolbox'
+cask 'docker-toolbox'
 cask 'disk-inventory-x'
 cask 'atom'
 


### PR DESCRIPTION
- dockertoolbox was renamed to docker-toolbox
