### PR TITLE
Remove qt because it is deprecated in OS X 10.11 and removed in 10.12

### DIFF
--- a/mac
+++ b/mac
@@ -116,7 +116,6 @@ brew 'postgres', restart_service: :changed
 brew 'the_silver_searcher'
 brew 'reattach-to-user-namespace'
 brew 'imagemagick'
-brew 'qt'
 brew 'node'
 brew 'rbenv'
 brew 'ruby-build'


### PR DESCRIPTION
Qt is deprecated in OS X 10.11 and removed in 10.12 and none of the formulae depend on it.
