### PR TITLE
Use docker for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ $ curl --remote-name https://raw.githubusercontent.com/recombine/laptop/master/m
 # Read through the script; ensure you have a general idea of what it will do:
 $ less ./mac
 
-# If your docker-machine is already set up and running, stop it first:
-$ docker-machine stop default
-
 # Execute the script
 $ ./mac
 ```

--- a/mac
+++ b/mac
@@ -71,11 +71,11 @@ gem_install_or_update() {
 }
 
 pip_install_or_upgrade() {
-  if pip list | grep "$1" > /dev/null; then
+  if pip2 list | grep "$1" > /dev/null; then
     fancy_echo "Upgrading pip package $1"
-    pip install --upgrade "$1" > /dev/null
+    pip2 install --upgrade "$1" > /dev/null
   else
-    pip install "$1"
+    pip2 install "$1"
   fi
 }
 

--- a/mac
+++ b/mac
@@ -135,7 +135,6 @@ brew 'awsebcli'
 # Useful apps
 cask 'google-chrome'
 cask 'slack'
-cask 'docker-toolbox'
 cask 'disk-inventory-x'
 cask 'atom'
 cask 'gpgtools'
@@ -172,11 +171,3 @@ gem_install_or_update 'bundler'
 fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
-
-if ! docker-machine ls | grep -Fq "default"; then
-  fancy_echo "Creating a local virtual machine for docker. Its name is 'default'. Its disk size is 80GB."
-  # We need around 80 GB for docker's virtual machine because our dev databases are so big
-  docker-machine create --driver virtualbox --virtualbox-disk-size "80000" default
-else
-  fancy_echo "A docker-machine named 'default' already exists. Skipping ..."
-fi


### PR DESCRIPTION
Remove things that assumed docker-toolbox as our new standard is downloading Docker for Mac from the website, not via homebrew.

Also fix broken `pip` command.